### PR TITLE
Fix progressive frame rates

### DIFF
--- a/src/cg.fth.1080p2500.as3proj
+++ b/src/cg.fth.1080p2500.as3proj
@@ -5,7 +5,7 @@
     <movie outputType="Application" />
     <movie input="" />
     <movie path="bin\cg22.fth.1080p2500" />
-    <movie fps="50" />
+    <movie fps="25" />
     <movie width="1920" />
     <movie height="1080" />
     <movie version="11" />

--- a/src/cg.fth.1080p2997.as3proj
+++ b/src/cg.fth.1080p2997.as3proj
@@ -5,7 +5,7 @@
     <movie outputType="Application" />
     <movie input="" />
     <movie path="bin\cg22.fth.1080p2997" />
-    <movie fps="60" />
+    <movie fps="30" />
     <movie width="1920" />
     <movie height="1080" />
     <movie version="11" />

--- a/src/cg.fth.1080p3000.as3proj
+++ b/src/cg.fth.1080p3000.as3proj
@@ -5,7 +5,7 @@
     <movie outputType="Application" />
     <movie input="" />
     <movie path="bin\cg22.fth.1080p3000" />
-    <movie fps="60" />
+    <movie fps="30" />
     <movie width="1920" />
     <movie height="1080" />
     <movie version="11" />

--- a/src/cg.fth.576p2500.as3proj
+++ b/src/cg.fth.576p2500.as3proj
@@ -5,7 +5,7 @@
     <movie outputType="Application" />
     <movie input="" />
     <movie path="bin\cg22.fth.576p2500" />
-    <movie fps="50" />
+    <movie fps="25" />
     <movie width="1024" />
     <movie height="576" />
     <movie version="11" />

--- a/src/cg.fth.720p2500.as3proj
+++ b/src/cg.fth.720p2500.as3proj
@@ -5,7 +5,7 @@
     <movie outputType="Application" />
     <movie input="" />
     <movie path="bin\cg22.fth.720p2500" />
-    <movie fps="50" />
+    <movie fps="25" />
     <movie width="1280" />
     <movie height="720" />
     <movie version="11" />

--- a/src/cg.fth.720p2997.as3proj
+++ b/src/cg.fth.720p2997.as3proj
@@ -5,7 +5,7 @@
     <movie outputType="Application" />
     <movie input="" />
     <movie path="bin\cg22.fth.720p2997" />
-    <movie fps="60" />
+    <movie fps="30" />
     <movie width="1280" />
     <movie height="720" />
     <movie version="11" />

--- a/src/cg.fth.720p3000.as3proj
+++ b/src/cg.fth.720p3000.as3proj
@@ -5,7 +5,7 @@
     <movie outputType="Application" />
     <movie input="" />
     <movie path="bin\cg22.fth.720p3000" />
-    <movie fps="60" />
+    <movie fps="30" />
     <movie width="1280" />
     <movie height="720" />
     <movie version="11" />


### PR DESCRIPTION
There are 7 template hosts that are for progressive output but have their frame rate doubled as though they were for interlaced.

This resolves that.